### PR TITLE
fix: remove unused exception data that may take an error

### DIFF
--- a/src/Bugtify.php
+++ b/src/Bugtify.php
@@ -112,7 +112,6 @@ class Bugtify
             'line'        => $exception->getLine(),
             'file'        => $exception->getFile(),
             'server'      => array_filter([
-                'user_agent'      => $_SERVER['HTTP_USER_AGENT'],
                 'protocol'        => $request->server('SERVER_PROTOCOL'),
                 'software'        => $request->server('SERVER_SOFTWARE'),
                 'php_version'     => PHP_VERSION,


### PR DESCRIPTION
Sometimes, HTTP_USER_AGENT will not have the value. And just to fix or make good from this data. Anyway need to remove it because don't use it anywhere for now.